### PR TITLE
Visualize with multiple subscriptions

### DIFF
--- a/.github/workflows/ci_pulsed_power_monitoring.yml
+++ b/.github/workflows/ci_pulsed_power_monitoring.yml
@@ -131,7 +131,7 @@ jobs:
       - name: Install emscripten
         uses: mymindstorm/setup-emsdk@v11
         with:
-          version: 2.0.14
+          version: 3.1.24
           # actions-cache-folder: "emsdk-cache"
 
       - name: Verify emscripten

--- a/src/implot_visualization/app/CMakeLists.txt
+++ b/src/implot_visualization/app/CMakeLists.txt
@@ -2,6 +2,7 @@ target_sources(index PRIVATE main.cpp)
 
 add_subdirectory(deserializer)
 add_subdirectory(fetch)
+add_subdirectory(plot_tools)
 
 # link the executable
 target_link_libraries(
@@ -10,4 +11,5 @@ target_link_libraries(
         implot
         deserializer
         fetch
+        plot_tools
 )

--- a/src/implot_visualization/app/deserializer/deserialize_json.cpp
+++ b/src/implot_visualization/app/deserializer/deserialize_json.cpp
@@ -46,10 +46,9 @@ void   Deserializer::addToSignalBuffers(std::vector<SignalBuffer> &signals, cons
     double value             = 0.0;
 
     for (int i = 0; i < acquisitionData.signalNames.size(); i++) {
-        signals[i].addFinished = false;
-        signals[i].signalName  = acquisitionData.signalNames[i];
-        int stride             = acquisitionData.strideArray.dims[1];
-        int offset             = i * stride;
+        signals[i].signalName = acquisitionData.signalNames[i];
+        int stride            = acquisitionData.strideArray.dims[1];
+        int offset            = i * stride;
 
         for (int j = 0; j < stride; j++) {
             absoluteTimestampPrev = absoluteTimestamp;
@@ -57,8 +56,6 @@ void   Deserializer::addToSignalBuffers(std::vector<SignalBuffer> &signals, cons
             value                 = acquisitionData.strideArray.values[offset + j];
             signals[i].addPoint(absoluteTimestamp, value);
         }
-
-        signals[i].addFinished = true;
     }
 }
 
@@ -83,6 +80,7 @@ void Deserializer::deserializeAcquisition(const std::string &jsonString, std::ve
         }
     }
 
+    lastRefTrigger = acquisition.refTrigger_ns;
     addToSignalBuffers(signals, acquisition);
 }
 

--- a/src/implot_visualization/app/deserializer/deserialize_json.cpp
+++ b/src/implot_visualization/app/deserializer/deserialize_json.cpp
@@ -112,11 +112,6 @@ void Deserializer::deserializeAcquisition(const std::string &jsonString, std::ve
         if (element.key() == "refTriggerStamp") {
             acquisition.refTrigger_ns = element.value();
             acquisition.refTrigger_s  = acquisition.refTrigger_ns / std::pow(10, 9);
-            // debug begin
-            auto   p1               = std::chrono::system_clock::now();
-            double acquisition_time = std::chrono::duration_cast<std::chrono::seconds>(p1.time_since_epoch()).count();
-            refTriggerTimestamps[0].addPoint(acquisition_time, acquisition.refTrigger_s);
-            // debug end
         } else if (element.key() == "channelTimeSinceRefTrigger") {
             acquisition.relativeTimestamps.insert(acquisition.relativeTimestamps.begin(), element.value().begin(), element.value().end());
         } else if (element.key() == "channelNames") {
@@ -131,6 +126,18 @@ void Deserializer::deserializeAcquisition(const std::string &jsonString, std::ve
             // }
         }
     }
+
+    // debug begin
+    auto   p1               = std::chrono::system_clock::now();
+    double acquisition_time = static_cast<double>(std::chrono::duration_cast<std::chrono::milliseconds>(p1.time_since_epoch()).count()) / 1000;
+    if (acquisition.signalNames[0] == "sinus@4000Hz") {
+        refTriggerTimestamps[0].addPoint(acquisition_time, acquisition.refTrigger_s);
+        refTriggerTimestamps[0].signalName = "sinus & square";
+    } else {
+        refTriggerTimestamps[1].addPoint(acquisition_time, acquisition.refTrigger_s);
+        refTriggerTimestamps[1].signalName = "saw";
+    }
+    // debug end
 
     addToSignalBuffers(signals, acquisition);
     // timestampsInBufferAreEquidistant(signals[0]);

--- a/src/implot_visualization/app/deserializer/deserialize_json.cpp
+++ b/src/implot_visualization/app/deserializer/deserialize_json.cpp
@@ -34,27 +34,74 @@ void SignalBuffer::erase() {
     }
 }
 
+DataPoint SignalBuffer::back() {
+    return data[maxSize - 1];
+}
+
+double absoluteTimestampPrev = 0.0;
+
+bool   timestampsInBufferAreEquidistant(SignalBuffer &buffer) {
+    bool   isEquidistant = true;
+    double timestampCurr = buffer.data[0].x;
+    double timestampPrev = buffer.data[0].x;
+    double dt            = 0.0;
+    for (int i = 0; i < buffer.data.size(); i++) {
+        timestampCurr = buffer.data[i].x;
+        dt            = timestampCurr - timestampPrev;
+        // std::cout << "dt: " << dt << std::endl;
+        if (dt < 0 || dt > 0.001) {
+            isEquidistant = false;
+            std::cout << "Timestamps in Buffer are not equidistant!" << std::endl;
+            // std::cout << "Previous timestamp: " << timestampPrev << std::endl;
+            // std::cout << "Current timestamp: " << timestampCurr << std::endl;
+            std::cout << "dt: " << dt << std::endl;
+            std::cout << "Buffer index: " << i << std::endl;
+        }
+        timestampPrev = timestampCurr;
+    }
+    return isEquidistant;
+}
+
 void Deserializer::addToSignalBuffers(std::vector<SignalBuffer> &signals, const Acquisition &acquisitionData) {
-    double absoluteTimestamp = 0.0;
+    double absoluteTimestamp = acquisitionData.refTrigger_s;
     double value             = 0.0;
 
     for (int i = 0; i < acquisitionData.signalNames.size(); i++) {
-        signals[i].signalName = acquisitionData.signalNames[i];
-        int stride            = acquisitionData.strideArray.dims[1];
-        int offset            = i * stride;
+        signals[i].addFinished = false;
+        signals[i].signalName  = acquisitionData.signalNames[i];
+        int stride             = acquisitionData.strideArray.dims[1];
+        int offset             = i * stride;
 
         for (int j = 0; j < stride; j++) {
-            absoluteTimestamp = acquisitionData.refTrigger_s + acquisitionData.relativeTimestamps[j];
-            value             = acquisitionData.strideArray.values[offset + j];
+            absoluteTimestampPrev = absoluteTimestamp;
+            absoluteTimestamp     = acquisitionData.refTrigger_s + acquisitionData.relativeTimestamps[j];
+            value                 = acquisitionData.strideArray.values[offset + j];
             signals[i].addPoint(absoluteTimestamp, value);
+
+            // debug
+            // if (acquisitionData.signalNames[i] == "square@4000Hz" && value < 0) {
+            //     std::cout << "Negative value detected!" << std::endl;
+            //     std::cout << "Json: " << value << std::endl;
+            //     // std::cout << "StrideArray dims: " << acquisitionData.strideArray.dims[0] << ", " << acquisitionData.strideArray.dims[1] << std::endl;
+            //     // std::cout << "Index: " << offset + j << std::endl;
+            //     // std::cout << "Array length: " << acquisitionData.strideArray.values.size() << std::endl;
+            //     // std::cout << "Buffer: " << signals[i].back().y << std::endl;
+            // }
+            // if (absoluteTimestamp - absoluteTimestampPrev > 0.005) {
+            //     std::cout << "Data loss detected by missing timestamps!" << std::endl;
+            //     std::cout << "Previous timestamp: " << absoluteTimestampPrev << std::endl;
+            //     std::cout << "Current timestamp: " << absoluteTimestamp << std::endl;
+            // }
         }
+
+        signals[i].addFinished = true;
     }
 }
 
 void Deserializer::deserializeAcquisition(const std::string &jsonString, std::vector<SignalBuffer> &signals) {
+    std::string modifiedJsonString = jsonString;
     Acquisition acquisition;
 
-    std::string modifiedJsonString = jsonString;
     modifiedJsonString.erase(0, 14);
 
     auto json_obj = json::parse(modifiedJsonString);
@@ -69,10 +116,16 @@ void Deserializer::deserializeAcquisition(const std::string &jsonString, std::ve
         } else if (element.key() == "channelValues") {
             acquisition.strideArray.dims   = std::vector<int>(element.value()["dims"]);
             acquisition.strideArray.values = std::vector<double>(element.value()["values"]);
+            // std::cout << "StrideArray dims: " << acquisition.strideArray.dims[0] << ", " << acquisition.strideArray.dims[1] << std::endl;
+            // std::cout << "Array length: " << acquisition.strideArray.values.size() << std::endl;
+            // if (acquisition.strideArray.dims[0] * acquisition.strideArray.dims[1] != acquisition.strideArray.values.size()) {
+            //     std::cout << "Vector size does not match dimensions!" << std::endl;
+            // }
         }
     }
 
     addToSignalBuffers(signals, acquisition);
+    timestampsInBufferAreEquidistant(signals[0]);
 }
 
 void Deserializer::deserializeCounter(const std::string &jsonString, std::vector<SignalBuffer> &signals) {
@@ -99,6 +152,7 @@ void Deserializer::deserializeCounter(const std::string &jsonString, std::vector
 }
 
 void Deserializer::deserializeJson(const std::string &jsonString, std::vector<SignalBuffer> &signals) {
+    // std::cout << jsonString << std::endl;
     if (jsonString.substr(1, 11) == "Acquisition") {
         deserializeAcquisition(jsonString, signals);
     } else if (jsonString.substr(1, 11) == "CounterData") {

--- a/src/implot_visualization/app/deserializer/deserialize_json.cpp
+++ b/src/implot_visualization/app/deserializer/deserialize_json.cpp
@@ -82,7 +82,7 @@ void Deserializer::deserializeAcquisition(const std::string &jsonString, std::ve
     addToSignalBuffers(signals, acquisition);
 }
 
-void Deserializer::deserializeJson(const std::string &jsonString, std::vector<SignalBuffer> &signals) {
+void Deserializer::deserializeJson(std::vector<SignalBuffer> &signals) {
     if (jsonString.substr(1, 11) == "Acquisition") {
         deserializeAcquisition(jsonString, signals);
     }

--- a/src/implot_visualization/app/deserializer/deserialize_json.h
+++ b/src/implot_visualization/app/deserializer/deserialize_json.h
@@ -43,13 +43,10 @@ struct Acquisition {
 };
 
 class Deserializer {
+    // public:
+    //     const std::string &jsonString;
+
 public:
-    /**
-     * @brief Deserializes json string
-     *
-     * @param jsonString string of type
-     * "Acquisition": {"value": key, "timestamp": key}
-     */
     void deserializeJson(const std::string &jsonString, std::vector<SignalBuffer> &signals);
 
 private:

--- a/src/implot_visualization/app/deserializer/deserialize_json.h
+++ b/src/implot_visualization/app/deserializer/deserialize_json.h
@@ -43,9 +43,10 @@ struct Acquisition {
 
 class Deserializer {
 public:
-    uint64_t lastRefTrigger = 0;
+    uint64_t    lastRefTrigger = 0;
+    std::string jsonString     = "";
 
-    void     deserializeJson(const std::string &jsonString, std::vector<SignalBuffer> &signals);
+    void        deserializeJson(std::vector<SignalBuffer> &signals);
 
 private:
     void deserializeAcquisition(const std::string &jsonString, std::vector<SignalBuffer> &signals);

--- a/src/implot_visualization/app/deserializer/deserialize_json.h
+++ b/src/implot_visualization/app/deserializer/deserialize_json.h
@@ -20,7 +20,6 @@ public:
     int                 offset;
     ImVector<DataPoint> data;
     std::string         signalName;
-    bool                addFinished = false;
 
     SignalBuffer(int max_size = 200'000);
 
@@ -43,11 +42,10 @@ struct Acquisition {
 };
 
 class Deserializer {
-    // public:
-    //     const std::string &jsonString;
-
 public:
-    void deserializeJson(const std::string &jsonString, std::vector<SignalBuffer> &signals);
+    uint64_t lastRefTrigger = 0;
+
+    void     deserializeJson(const std::string &jsonString, std::vector<SignalBuffer> &signals);
 
 private:
     void deserializeAcquisition(const std::string &jsonString, std::vector<SignalBuffer> &signals);

--- a/src/implot_visualization/app/deserializer/deserialize_json.h
+++ b/src/implot_visualization/app/deserializer/deserialize_json.h
@@ -49,6 +49,5 @@ public:
 
 private:
     void deserializeAcquisition(const std::string &jsonString, std::vector<SignalBuffer> &signals);
-    void deserializeCounter(const std::string &jsonString, std::vector<SignalBuffer> &signals);
     void addToSignalBuffers(std::vector<SignalBuffer> &signals, const Acquisition &acquisitionData);
 };

--- a/src/implot_visualization/app/deserializer/deserialize_json.h
+++ b/src/implot_visualization/app/deserializer/deserialize_json.h
@@ -20,11 +20,13 @@ public:
     int                 offset;
     ImVector<DataPoint> data;
     std::string         signalName;
+    bool                addFinished = false;
 
     SignalBuffer(int max_size = 200'000);
 
-    void addPoint(double x, double y);
-    void erase();
+    void      addPoint(double x, double y);
+    void      erase();
+    DataPoint back();
 };
 
 struct StrideArray {

--- a/src/implot_visualization/app/fetch/emscripten_fetch.cpp
+++ b/src/implot_visualization/app/fetch/emscripten_fetch.cpp
@@ -36,7 +36,7 @@ FetchUtils::FetchUtils(const char *_url, const int numSignals) {
     url = _url;
     std::vector<SignalBuffer> _signals(numSignals);
     signals     = _signals;
-    extendedUrl = std::format("{}&longPollingIndex={}", url, "0");
+    extendedUrl = std::format("{}&lastRefTrigger=0", url);
 }
 
 void FetchUtils::fetch() {
@@ -55,7 +55,7 @@ void FetchUtils::fetch() {
         fetchFinished = false;
     }
     if (fetchSuccessful) {
-        deserializer->deserializeJson(jsonString, signals);
+        deserializer.deserializeJson(jsonString, signals);
         updateUrl();
         fetchSuccessful = false;
         fetchFinished   = true;
@@ -63,6 +63,5 @@ void FetchUtils::fetch() {
 }
 
 void FetchUtils::updateUrl() {
-    longPollingIndex++;
-    extendedUrl = std::format("{}&longPollingIndex={}", url, std::to_string(longPollingIndex));
+    extendedUrl = std::format("{}&lastRefTrigger={}", url, std::to_string(deserializer.lastRefTrigger));
 }

--- a/src/implot_visualization/app/fetch/emscripten_fetch.cpp
+++ b/src/implot_visualization/app/fetch/emscripten_fetch.cpp
@@ -25,7 +25,7 @@ void downloadFailed(emscripten_fetch_t *fetch) {
     fetch_finished = true;
 }
 
-void fetch(const char *url, std::vector<SignalBuffer> &signals, Deserializer *deserializer) {
+bool fetch(const char *url, std::vector<SignalBuffer> &signals, Deserializer *deserializer) {
     emscripten_fetch_attr_t attr;
     emscripten_fetch_attr_init(&attr);
     strcpy(attr.requestMethod, "GET");
@@ -39,7 +39,11 @@ void fetch(const char *url, std::vector<SignalBuffer> &signals, Deserializer *de
         fetch_finished = false;
     }
     if (fetch_successful) {
+        std::cout << url << std::endl;
+        std::cout << jsonString << std::endl;
         deserializer->deserializeJson(jsonString, signals);
         fetch_successful = false;
+        fetch_finished   = true;
     }
+    return fetch_finished;
 }

--- a/src/implot_visualization/app/fetch/emscripten_fetch.cpp
+++ b/src/implot_visualization/app/fetch/emscripten_fetch.cpp
@@ -43,12 +43,12 @@ void FetchUtils::fetch() {
     emscripten_fetch_attr_t attr;
     emscripten_fetch_attr_init(&attr);
     strcpy(attr.requestMethod, "GET");
-    static const char *custom_headers[3] = { "X-OPENCMW-METHOD", "POLL", nullptr };
-    attr.requestHeaders                  = custom_headers;
-    attr.attributes                      = EMSCRIPTEN_FETCH_LOAD_TO_MEMORY;
-    attr.onsuccess                       = onDownloadSucceeded;
-    attr.onerror                         = onDownloadFailed;
-    attr.userData                        = this;
+    // static const char *custom_headers[3] = { "X-OPENCMW-METHOD", "POLL", nullptr };
+    // attr.requestHeaders = custom_headers;
+    attr.attributes = EMSCRIPTEN_FETCH_LOAD_TO_MEMORY;
+    attr.onsuccess  = onDownloadSucceeded;
+    attr.onerror    = onDownloadFailed;
+    attr.userData   = this;
 
     if (fetchFinished) {
         emscripten_fetch(&attr, extendedUrl.c_str());

--- a/src/implot_visualization/app/fetch/emscripten_fetch.cpp
+++ b/src/implot_visualization/app/fetch/emscripten_fetch.cpp
@@ -8,7 +8,7 @@
 
 std::string jsonString;
 
-void        FetchUtils::downloadSucceeded(emscripten_fetch_t *fetch) {
+void        Subscription::downloadSucceeded(emscripten_fetch_t *fetch) {
     // The data is now available at fetch->data[0] through fetch->data[fetch->numBytes-1];
     jsonString.assign(fetch->data, fetch->numBytes);
     fetchSuccessful = true;
@@ -16,30 +16,30 @@ void        FetchUtils::downloadSucceeded(emscripten_fetch_t *fetch) {
     emscripten_fetch_close(fetch); // Free data associated with the fetch.
 }
 
-void FetchUtils::downloadFailed(emscripten_fetch_t *fetch) {
+void Subscription::downloadFailed(emscripten_fetch_t *fetch) {
     printf("Downloading %s failed, HTTP failure status code: %d.\n", fetch->url, fetch->status);
     emscripten_fetch_close(fetch); // Also free data on failure.
     fetchFinished = true;
 }
 
 void onDownloadSucceeded(emscripten_fetch_t *fetch) {
-    FetchUtils *fetchUtils = static_cast<FetchUtils *>(fetch->userData);
+    Subscription *fetchUtils = static_cast<Subscription *>(fetch->userData);
     fetchUtils->downloadSucceeded(fetch);
 }
 
 void onDownloadFailed(emscripten_fetch_t *fetch) {
-    FetchUtils *fetchUtils = static_cast<FetchUtils *>(fetch->userData);
+    Subscription *fetchUtils = static_cast<Subscription *>(fetch->userData);
     fetchUtils->downloadFailed(fetch);
 }
 
-FetchUtils::FetchUtils(const char *_url, const int numSignals) {
+Subscription::Subscription(const char *_url, const int numSignals) {
     url = _url;
     std::vector<SignalBuffer> _signals(numSignals);
     signals     = _signals;
     extendedUrl = std::format("{}&lastRefTrigger=0", url);
 }
 
-void FetchUtils::fetch() {
+void Subscription::fetch() {
     emscripten_fetch_attr_t attr;
     emscripten_fetch_attr_init(&attr);
     strcpy(attr.requestMethod, "GET");
@@ -62,6 +62,6 @@ void FetchUtils::fetch() {
     }
 }
 
-void FetchUtils::updateUrl() {
+void Subscription::updateUrl() {
     extendedUrl = std::format("{}&lastRefTrigger={}", url, std::to_string(deserializer.lastRefTrigger));
 }

--- a/src/implot_visualization/app/fetch/emscripten_fetch.h
+++ b/src/implot_visualization/app/fetch/emscripten_fetch.h
@@ -8,8 +8,8 @@ class Subscription {
 public:
     std::string               url;
     std::vector<SignalBuffer> signals;
-    volatile bool             fetchFinished   = true;
-    volatile bool             fetchSuccessful = false;
+    bool                      fetchFinished   = true;
+    bool                      fetchSuccessful = false;
 
     Subscription(const std::string _url, const std::vector<std::string> &_requestedSignals);
 

--- a/src/implot_visualization/app/fetch/emscripten_fetch.h
+++ b/src/implot_visualization/app/fetch/emscripten_fetch.h
@@ -4,6 +4,6 @@
 #include <emscripten.h>
 #include <emscripten/fetch.h>
 
-void fetch(const char *url, std::vector<SignalBuffer> &signals, Deserializer *deserializer);
+bool fetch(const char *url, std::vector<SignalBuffer> &signals, Deserializer *deserializer);
 void downloadSucceeded(emscripten_fetch_t *fetch);
 void downloadFailed(emscripten_fetch_t *fetch);

--- a/src/implot_visualization/app/fetch/emscripten_fetch.h
+++ b/src/implot_visualization/app/fetch/emscripten_fetch.h
@@ -4,6 +4,23 @@
 #include <emscripten.h>
 #include <emscripten/fetch.h>
 
-bool fetch(const char *url, std::vector<SignalBuffer> &signals, Deserializer *deserializer);
-void downloadSucceeded(emscripten_fetch_t *fetch);
-void downloadFailed(emscripten_fetch_t *fetch);
+class FetchUtils {
+public:
+    const char               *url;
+    std::vector<SignalBuffer> signals;
+    volatile bool             fetchFinished   = true;
+    volatile bool             fetchSuccessful = false;
+    std::string               extendedUrl;
+
+    FetchUtils(const char *_url, int numSignals);
+    void fetch();
+    void downloadSucceeded(emscripten_fetch_t *fetch);
+    void downloadFailed(emscripten_fetch_t *fetch);
+
+private:
+    Deserializer *deserializer;
+    uint64_t      latestTimestamp;
+    int           longPollingIndex = 0;
+
+    void          updateUrl();
+};

--- a/src/implot_visualization/app/fetch/emscripten_fetch.h
+++ b/src/implot_visualization/app/fetch/emscripten_fetch.h
@@ -10,17 +10,16 @@ public:
     std::vector<SignalBuffer> signals;
     volatile bool             fetchFinished   = true;
     volatile bool             fetchSuccessful = false;
-    std::string               extendedUrl;
 
     FetchUtils(const char *_url, int numSignals);
+
     void fetch();
     void downloadSucceeded(emscripten_fetch_t *fetch);
     void downloadFailed(emscripten_fetch_t *fetch);
 
 private:
-    Deserializer *deserializer;
-    uint64_t      latestTimestamp;
-    int           longPollingIndex = 0;
+    Deserializer deserializer;
+    std::string  extendedUrl;
 
-    void          updateUrl();
+    void         updateUrl();
 };

--- a/src/implot_visualization/app/fetch/emscripten_fetch.h
+++ b/src/implot_visualization/app/fetch/emscripten_fetch.h
@@ -6,20 +6,21 @@
 
 class Subscription {
 public:
-    const char               *url;
+    std::string               url;
     std::vector<SignalBuffer> signals;
     volatile bool             fetchFinished   = true;
     volatile bool             fetchSuccessful = false;
 
-    Subscription(const char *_url, int numSignals);
+    Subscription(const std::string _url, const std::vector<std::string> &_requestedSignals);
 
     void fetch();
     void downloadSucceeded(emscripten_fetch_t *fetch);
     void downloadFailed(emscripten_fetch_t *fetch);
 
 private:
-    Deserializer deserializer;
-    std::string  extendedUrl;
+    std::vector<std::string> requestedSignals;
+    Deserializer             deserializer;
+    std::string              extendedUrl;
 
-    void         updateUrl();
+    void                     updateUrl();
 };

--- a/src/implot_visualization/app/fetch/emscripten_fetch.h
+++ b/src/implot_visualization/app/fetch/emscripten_fetch.h
@@ -4,14 +4,14 @@
 #include <emscripten.h>
 #include <emscripten/fetch.h>
 
-class FetchUtils {
+class Subscription {
 public:
     const char               *url;
     std::vector<SignalBuffer> signals;
     volatile bool             fetchFinished   = true;
     volatile bool             fetchSuccessful = false;
 
-    FetchUtils(const char *_url, int numSignals);
+    Subscription(const char *_url, int numSignals);
 
     void fetch();
     void downloadSucceeded(emscripten_fetch_t *fetch);

--- a/src/implot_visualization/app/main.cpp
+++ b/src/implot_visualization/app/main.cpp
@@ -16,8 +16,8 @@
 #include <emscripten_fetch.h>
 #include <plot_tools.h>
 
-FetchUtils              fetchGrSignals("http://192.168.56.101:8080/pulsed_power/Acquisition?channelNameFilter=sinus@4000Hz", 1);
-FetchUtils              fetchPowerSignals("http://192.168.56.101:8080/pulsed_power/Acquisition?channelNameFilter=saw@4000Hz,square@4000Hz", 2);
+FetchUtils              fetchGrSignals("http://192.168.56.101:8080/pulsed_power/Acquisition?channelNameFilter=sinus@4000Hz,square@4000Hz", 2);
+FetchUtils              fetchPowerSignals("http://192.168.56.101:8080/pulsed_power/Acquisition?channelNameFilter=saw@4000Hz", 1);
 std::vector<FetchUtils> subscriptions = { fetchGrSignals, fetchPowerSignals };
 
 Plotter                 plotter;

--- a/src/implot_visualization/app/main.cpp
+++ b/src/implot_visualization/app/main.cpp
@@ -17,8 +17,7 @@
 
 std::vector<SignalBuffer> signals1(3);
 std::vector<SignalBuffer> signals2(2);
-std::vector<SignalBuffer> refTriggerTimestamps(1);
-std::vector<std::string>  subscriptions;
+std::vector<SignalBuffer> refTriggerTimestamps(2);
 
 bool                      fetch_finished_1 = true;
 bool                      fetch_finished_2 = true;
@@ -129,28 +128,15 @@ static void main_loop(void *arg) {
     ImGui_ImplSDL2_NewFrame();
     ImGui::NewFrame();
 
-    // Visualize One GR SignalBuffer
+    // FAIR Visualization
     if (visualize_gr_signal) {
-        // one subscription
         static Deserializer deserializer;
-        fetch("http://192.168.56.101:8080/pulsed_power/Acquisition?channelNameFilter=sinus@4000Hz,saw@4000Hz,square@4000Hz", signals1, &deserializer);
-
-        // // two subscriptions
-        // static Deserializer deserializer;
-        // static Deserializer deserializer2;
-        // // fetch_finished = fetch("http://192.168.56.101:8080/pulsed_power/Acquisition?channelNameFilter=saw@4000Hz,square@4000Hz", signals1, &deserializer);
-        // // static Deserializer deserializer2;
-        // // fetch_finished = fetch("http://192.168.56.101:8080/pulsed_power/Acquisition?channelNameFilter=sinus@4000Hz", signals2, &deserializer2);
-        // if (fetch_finished_2) {
-        //     // std::this_thread::sleep_for(std::chrono::milliseconds(50));
-        //     std::cout << "Starting fetch" << std::endl;
-        //     fetch_finished_1 = fetch("http://192.168.56.101:8080/pulsed_power/Acquisition?channelNameFilter=saw@4000Hz", signals1, &deserializer);
-        // }
-        // if (fetch_finished_1) {
-        //     // std::this_thread::sleep_for(std::chrono::milliseconds(50));
-        //     std::cout << "Starting sinus fetch" << std::endl;
-        //     fetch_finished_2 = fetch("http://192.168.56.101:8080/pulsed_power/Acquisition?channelNameFilter=sinus@4000Hz", signals2, &deserializer2);
-        // }
+        if (fetch_finished_2) {
+            fetch_finished_1 = fetch("http://192.168.56.101:8080/pulsed_power/Acquisition?channelNameFilter=sinus@4000Hz,square@4000Hz", signals1, &deserializer);
+        }
+        if (fetch_finished_1) {
+            fetch_finished_2 = fetch("http://192.168.56.101:8080/pulsed_power/Acquisition?channelNameFilter=saw@4000Hz", signals2, &deserializer);
+        }
 
         ImGui::SetNextWindowPos(ImVec2(0, 0), ImGuiCond_FirstUseEver);
         ImGui::SetNextWindowSize(ImVec2(window_width, window_height), ImGuiCond_None);
@@ -159,7 +145,7 @@ static void main_loop(void *arg) {
         ImGui::ShowStyleSelector("Colors##Selector");
 
         static ImPlotSubplotFlags flags     = ImPlotSubplotFlags_NoTitle;
-        static int                rows      = 2;
+        static int                rows      = 3;
         static int                cols      = 2;
         static float              rratios[] = { 1, 1, 1, 1 };
         static float              cratios[] = { 1, 1, 1, 1 };
@@ -216,33 +202,6 @@ static void main_loop(void *arg) {
                 ImPlot::EndPlot();
             }
 
-            // Plot Acquisition Timestamps
-            // if (ImPlot::BeginPlot("Power")) {
-            //     static ImPlotAxisFlags xflags = ImPlotAxisFlags_None;
-            //     static ImPlotAxisFlags yflags = ImPlotAxisFlags_AutoFit | ImPlotAxisFlags_RangeFit;
-            //     // Setup x-Axis
-            //     ImPlot::SetupAxes("time (s)", "P(W), Q(Var), S(VA)", xflags, yflags);
-            //     auto   clock       = std::chrono::system_clock::now();
-            //     double currentTime = (std::chrono::duration_cast<std::chrono::milliseconds>(clock.time_since_epoch()).count()) / 1000.0;
-            //     ImPlot::SetupAxisLimits(ImAxis_X1, currentTime - 10.0, currentTime, ImGuiCond_Always);
-            //     ImPlot::SetupAxisScale(ImAxis_X1, ImPlotScale_Time);
-            //     ImPlot::SetupAxis(ImAxis_Y2, "phi(deg)", ImPlotAxisFlags_AuxDefault);
-            //     ImPlot::SetNextFillStyle(IMPLOT_AUTO_COL, 0.5f);
-            //     ImPlot::SetNextMarkerStyle(ImPlotMarker_Circle);
-            //     for (int i = 0; i < refTriggerTimestamps.size(); i++) {
-            //         if (refTriggerTimestamps[i].data.size() > 0) {
-            //             ImPlot::PlotLine((refTriggerTimestamps[i].signalName).c_str(),
-            //                     &refTriggerTimestamps[i].data[0].x,
-            //                     &refTriggerTimestamps[i].data[0].y,
-            //                     refTriggerTimestamps[i].data.size(),
-            //                     0,
-            //                     refTriggerTimestamps[i].offset,
-            //                     2 * sizeof(double));
-            //         }
-            //     }
-            //     ImPlot::EndPlot();
-            // }
-
             // Mains Frequency Plot
             if (ImPlot::BeginPlot("Mains Frequency")) {
                 static ImPlotAxisFlags xflags = ImPlotAxisFlags_None;
@@ -256,6 +215,33 @@ static void main_loop(void *arg) {
                 // if (buffer.Data.size() > 0) {
                 //     // ImPlot::PlotLine("Sinus", &buffer.Data[0].x, &buffer.Data[0].y, buffer.Data.size(), 0, buffer.Offset, 2 * sizeof(double));
                 // }
+                ImPlot::EndPlot();
+            }
+
+            // Plot Acquisition Timestamps
+            if (ImPlot::BeginPlot("Power")) {
+                static ImPlotAxisFlags xflags = ImPlotAxisFlags_None;
+                static ImPlotAxisFlags yflags = ImPlotAxisFlags_AutoFit | ImPlotAxisFlags_RangeFit;
+                // Setup x-Axis
+                ImPlot::SetupAxes("time (s)", "P(W), Q(Var), S(VA)", xflags, yflags);
+                auto   clock       = std::chrono::system_clock::now();
+                double currentTime = (std::chrono::duration_cast<std::chrono::milliseconds>(clock.time_since_epoch()).count()) / 1000.0;
+                ImPlot::SetupAxisLimits(ImAxis_X1, currentTime - 10.0, currentTime, ImGuiCond_Always);
+                ImPlot::SetupAxisScale(ImAxis_X1, ImPlotScale_Time);
+                ImPlot::SetupAxis(ImAxis_Y2, "phi(deg)", ImPlotAxisFlags_AuxDefault);
+                for (int i = 0; i < refTriggerTimestamps.size(); i++) {
+                    ImPlot::SetNextMarkerStyle(ImPlotMarker_Circle);
+                    ImPlot::SetNextFillStyle(IMPLOT_AUTO_COL, 0.5f);
+                    if (refTriggerTimestamps[i].data.size() > 0) {
+                        ImPlot::PlotLine((refTriggerTimestamps[i].signalName).c_str(),
+                                &refTriggerTimestamps[i].data[0].x,
+                                &refTriggerTimestamps[i].data[0].y,
+                                refTriggerTimestamps[i].data.size(),
+                                0,
+                                refTriggerTimestamps[i].offset,
+                                2 * sizeof(double));
+                    }
+                }
                 ImPlot::EndPlot();
             }
         }

--- a/src/implot_visualization/app/main.cpp
+++ b/src/implot_visualization/app/main.cpp
@@ -17,7 +17,8 @@
 
 std::vector<SignalBuffer> signals1(3);
 std::vector<SignalBuffer> signals2(2);
-std::vector<SignalBuffer> refTriggerTimeStamps(1);
+std::vector<SignalBuffer> refTriggerTimestamps(1);
+std::vector<std::string>  subscriptions;
 
 bool                      fetch_finished_1 = true;
 bool                      fetch_finished_2 = true;
@@ -130,26 +131,26 @@ static void main_loop(void *arg) {
 
     // Visualize One GR SignalBuffer
     if (visualize_gr_signal) {
-        // // one subscription
-        // static Deserializer deserializer;
-        // fetch("http://192.168.56.101:8080/pulsed_power/Acquisition?channelNameFilter=sinus@4000Hz", signals1, &deserializer);
-
-        // two subscriptions
+        // one subscription
         static Deserializer deserializer;
-        static Deserializer deserializer2;
-        // fetch_finished = fetch("http://192.168.56.101:8080/pulsed_power/Acquisition?channelNameFilter=saw@4000Hz,square@4000Hz", signals1, &deserializer);
+        fetch("http://192.168.56.101:8080/pulsed_power/Acquisition?channelNameFilter=sinus@4000Hz,saw@4000Hz,square@4000Hz", signals1, &deserializer);
+
+        // // two subscriptions
+        // static Deserializer deserializer;
         // static Deserializer deserializer2;
-        // fetch_finished = fetch("http://192.168.56.101:8080/pulsed_power/Acquisition?channelNameFilter=sinus@4000Hz", signals2, &deserializer2);
-        if (fetch_finished_2) {
-            // std::this_thread::sleep_for(std::chrono::milliseconds(50));
-            std::cout << "Starting fetch" << std::endl;
-            fetch_finished_1 = fetch("http://192.168.56.101:8080/pulsed_power/Acquisition?channelNameFilter=saw@4000Hz", signals1, &deserializer);
-        }
-        if (fetch_finished_1) {
-            // std::this_thread::sleep_for(std::chrono::milliseconds(50));
-            std::cout << "Starting sinus fetch" << std::endl;
-            fetch_finished_2 = fetch("http://192.168.56.101:8080/pulsed_power/Acquisition?channelNameFilter=sinus@4000Hz", signals2, &deserializer2);
-        }
+        // // fetch_finished = fetch("http://192.168.56.101:8080/pulsed_power/Acquisition?channelNameFilter=saw@4000Hz,square@4000Hz", signals1, &deserializer);
+        // // static Deserializer deserializer2;
+        // // fetch_finished = fetch("http://192.168.56.101:8080/pulsed_power/Acquisition?channelNameFilter=sinus@4000Hz", signals2, &deserializer2);
+        // if (fetch_finished_2) {
+        //     // std::this_thread::sleep_for(std::chrono::milliseconds(50));
+        //     std::cout << "Starting fetch" << std::endl;
+        //     fetch_finished_1 = fetch("http://192.168.56.101:8080/pulsed_power/Acquisition?channelNameFilter=saw@4000Hz", signals1, &deserializer);
+        // }
+        // if (fetch_finished_1) {
+        //     // std::this_thread::sleep_for(std::chrono::milliseconds(50));
+        //     std::cout << "Starting sinus fetch" << std::endl;
+        //     fetch_finished_2 = fetch("http://192.168.56.101:8080/pulsed_power/Acquisition?channelNameFilter=sinus@4000Hz", signals2, &deserializer2);
+        // }
 
         ImGui::SetNextWindowPos(ImVec2(0, 0), ImGuiCond_FirstUseEver);
         ImGui::SetNextWindowSize(ImVec2(window_width, window_height), ImGuiCond_None);
@@ -174,7 +175,8 @@ static void main_loop(void *arg) {
                 ImPlot::SetupAxisScale(ImAxis_X1, ImPlotScale_Time);
                 ImPlot::SetNextFillStyle(IMPLOT_AUTO_COL, 0.5f);
                 for (int i = 0; i < signals1.size(); i++) {
-                    if (signals1[i].data.size() > 0 && signals1[i].addFinished) {
+                    // if (signals1[i].data.size() > 0 && signals1[i].addFinished) {
+                    if (signals1[i].data.size() > 0) {
                         ImPlot::PlotLine((signals1[i].signalName).c_str(), &signals1[i].data[0].x, &signals1[i].data[0].y, signals1[i].data.size(), 0, signals1[i].offset, 2 * sizeof(double));
                     }
                 }
@@ -206,7 +208,6 @@ static void main_loop(void *arg) {
                 ImPlot::SetupAxisScale(ImAxis_X1, ImPlotScale_Time);
                 ImPlot::SetupAxis(ImAxis_Y2, "phi(deg)", ImPlotAxisFlags_AuxDefault);
                 ImPlot::SetNextFillStyle(IMPLOT_AUTO_COL, 0.5f);
-                std::cout << signals2[1].data.size() << std::endl;
                 for (int i = 0; i < signals2.size(); i++) {
                     if (signals2[i].data.size() > 0) {
                         ImPlot::PlotLine((signals2[i].signalName).c_str(), &signals2[i].data[0].x, &signals2[i].data[0].y, signals2[i].data.size(), 0, signals2[i].offset, 2 * sizeof(double));
@@ -214,6 +215,33 @@ static void main_loop(void *arg) {
                 }
                 ImPlot::EndPlot();
             }
+
+            // Plot Acquisition Timestamps
+            // if (ImPlot::BeginPlot("Power")) {
+            //     static ImPlotAxisFlags xflags = ImPlotAxisFlags_None;
+            //     static ImPlotAxisFlags yflags = ImPlotAxisFlags_AutoFit | ImPlotAxisFlags_RangeFit;
+            //     // Setup x-Axis
+            //     ImPlot::SetupAxes("time (s)", "P(W), Q(Var), S(VA)", xflags, yflags);
+            //     auto   clock       = std::chrono::system_clock::now();
+            //     double currentTime = (std::chrono::duration_cast<std::chrono::milliseconds>(clock.time_since_epoch()).count()) / 1000.0;
+            //     ImPlot::SetupAxisLimits(ImAxis_X1, currentTime - 10.0, currentTime, ImGuiCond_Always);
+            //     ImPlot::SetupAxisScale(ImAxis_X1, ImPlotScale_Time);
+            //     ImPlot::SetupAxis(ImAxis_Y2, "phi(deg)", ImPlotAxisFlags_AuxDefault);
+            //     ImPlot::SetNextFillStyle(IMPLOT_AUTO_COL, 0.5f);
+            //     ImPlot::SetNextMarkerStyle(ImPlotMarker_Circle);
+            //     for (int i = 0; i < refTriggerTimestamps.size(); i++) {
+            //         if (refTriggerTimestamps[i].data.size() > 0) {
+            //             ImPlot::PlotLine((refTriggerTimestamps[i].signalName).c_str(),
+            //                     &refTriggerTimestamps[i].data[0].x,
+            //                     &refTriggerTimestamps[i].data[0].y,
+            //                     refTriggerTimestamps[i].data.size(),
+            //                     0,
+            //                     refTriggerTimestamps[i].offset,
+            //                     2 * sizeof(double));
+            //         }
+            //     }
+            //     ImPlot::EndPlot();
+            // }
 
             // Mains Frequency Plot
             if (ImPlot::BeginPlot("Mains Frequency")) {

--- a/src/implot_visualization/app/main.cpp
+++ b/src/implot_visualization/app/main.cpp
@@ -16,8 +16,8 @@
 #include <emscripten_fetch.h>
 #include <plot_tools.h>
 
-FetchUtils              fetchGrSignals("http://192.168.56.101:8080/pulsed_power/Acquisition?channelNameFilter=sinus@4000Hz,square@4000Hz", 2);
-FetchUtils              fetchPowerSignals("http://192.168.56.101:8080/pulsed_power/Acquisition?channelNameFilter=saw@4000Hz", 1);
+FetchUtils              fetchGrSignals("http://localhost:8080/pulsed_power/Acquisition?channelNameFilter=sinus@4000Hz,square@4000Hz", 2);
+FetchUtils              fetchPowerSignals("http://localhost:8080/pulsed_power/Acquisition?channelNameFilter=saw@4000Hz", 1);
 std::vector<FetchUtils> subscriptions = { fetchGrSignals, fetchPowerSignals };
 
 Plotter                 plotter;
@@ -96,7 +96,7 @@ int           main(int, char **) {
 #endif
 
     // This function call won't return, and will engage in an infinite loop, processing events from the browser, and dispatching them.
-    emscripten_set_main_loop_arg(main_loop, NULL, 0, true);
+    emscripten_set_main_loop_arg(main_loop, NULL, 25, true);
     // emscripten_set_main_loop_timing(EM_TIMING_SETIMMEDIATE, 10);
 }
 

--- a/src/implot_visualization/app/plot_tools/CMakeLists.txt
+++ b/src/implot_visualization/app/plot_tools/CMakeLists.txt
@@ -1,0 +1,17 @@
+add_library(
+    plot_tools OBJECT
+        "plot_tools.cpp"
+)
+
+target_include_directories(
+    plot_tools BEFORE
+    PUBLIC
+        ${CMAKE_CURRENT_SOURCE_DIR}
+)
+
+target_link_libraries(
+    plot_tools
+    PUBLIC
+        deserializer
+        implot
+)

--- a/src/implot_visualization/app/plot_tools/plot_tools.cpp
+++ b/src/implot_visualization/app/plot_tools/plot_tools.cpp
@@ -1,0 +1,91 @@
+
+#include <deserialize_json.h>
+#include <implot.h>
+#include <plot_tools.h>
+#include <vector>
+
+void Plotter::plotSignals(std::vector<SignalBuffer> &signals) {
+    for (int i = 0; i < signals.size(); i++) {
+        if (signals[i].data.size() > 0) {
+            ImPlot::PlotLine((signals[i].signalName).c_str(),
+                    &signals[i].data[0].x,
+                    &signals[i].data[0].y,
+                    signals[i].data.size(),
+                    0,
+                    signals[i].offset,
+                    2 * sizeof(double));
+        }
+    }
+}
+
+void Plotter::plotGrSignals(std::vector<SignalBuffer> &signals) {
+    static ImPlotAxisFlags xflags = ImPlotAxisFlags_None;
+    static ImPlotAxisFlags yflags = ImPlotAxisFlags_AutoFit | ImPlotAxisFlags_RangeFit;
+    ImPlot::SetupAxes("UTC Time", "Value", xflags, yflags);
+    auto   clock       = std::chrono::system_clock::now();
+    double currentTime = (std::chrono::duration_cast<std::chrono::milliseconds>(clock.time_since_epoch()).count()) / 1000.0;
+    ImPlot::SetupAxisLimits(ImAxis_X1, currentTime - 10.0, currentTime, ImGuiCond_Always);
+    ImPlot::SetupAxisScale(ImAxis_X1, ImPlotScale_Time);
+    ImPlot::SetNextFillStyle(IMPLOT_AUTO_COL, 0.5f);
+    plotSignals(signals);
+}
+
+void Plotter::plotBandpassFilter(std::vector<SignalBuffer> &signals) {
+    static ImPlotAxisFlags xflags = ImPlotAxisFlags_None;
+    static ImPlotAxisFlags yflags = ImPlotAxisFlags_AutoFit | ImPlotAxisFlags_RangeFit;
+    ImPlot::SetupAxes("time (ms)", "I(A)", xflags, yflags);
+    ImPlot::SetupAxisLimits(ImAxis_X1, 0, 60, ImGuiCond_Always);
+    ImPlot::SetNextFillStyle(IMPLOT_AUTO_COL, 0.5f);
+    // if (buffer.Data.size() > 0) {
+    //     // ImPlot::PlotLine("Sinus", &buffer.Data[0].x, &buffer.Data[0].y, buffer.Data.size(), 0, buffer.Offset, 2 * sizeof(double));
+    // }
+}
+
+void Plotter::plotPower(std::vector<SignalBuffer> &signals) {
+    static ImPlotAxisFlags xflags = ImPlotAxisFlags_None;
+    static ImPlotAxisFlags yflags = ImPlotAxisFlags_AutoFit | ImPlotAxisFlags_RangeFit;
+    // Setup x-Axis
+    ImPlot::SetupAxes("time (s)", "P(W), Q(Var), S(VA)", xflags, yflags);
+    auto   clock       = std::chrono::system_clock::now();
+    double currentTime = (std::chrono::duration_cast<std::chrono::milliseconds>(clock.time_since_epoch()).count()) / 1000.0;
+    ImPlot::SetupAxisLimits(ImAxis_X1, currentTime - 10.0, currentTime, ImGuiCond_Always);
+    ImPlot::SetupAxisScale(ImAxis_X1, ImPlotScale_Time);
+    ImPlot::SetupAxis(ImAxis_Y2, "phi(deg)", ImPlotAxisFlags_AuxDefault);
+    ImPlot::SetNextFillStyle(IMPLOT_AUTO_COL, 0.5f);
+    for (int i = 0; i < signals.size(); i++) {
+        if (signals[i].data.size() > 0) {
+            ImPlot::PlotLine((signals[i].signalName).c_str(),
+                    &signals[i].data[0].x,
+                    &signals[i].data[0].y,
+                    signals[i].data.size(),
+                    0,
+                    signals[i].offset,
+                    2 * sizeof(double));
+        }
+    }
+}
+
+void Plotter::plotMainsFrequency(std::vector<SignalBuffer> &signals) {
+    static ImPlotAxisFlags xflags = ImPlotAxisFlags_None;
+    static ImPlotAxisFlags yflags = ImPlotAxisFlags_AutoFit | ImPlotAxisFlags_RangeFit;
+    ImPlot::SetupAxes("time (s)", "Frequency (Hz)", xflags, yflags);
+    auto   clock       = std::chrono::system_clock::now();
+    double currentTime = (std::chrono::duration_cast<std::chrono::milliseconds>(clock.time_since_epoch()).count()) / 1000.0;
+    ImPlot::SetupAxisLimits(ImAxis_X1, currentTime - 10.0, currentTime, ImGuiCond_Always);
+    ImPlot::SetupAxisScale(ImAxis_X1, ImPlotScale_Time);
+    ImPlot::SetNextFillStyle(IMPLOT_AUTO_COL, 0.5f);
+    // if (buffer.Data.size() > 0) {
+    //     // ImPlot::PlotLine("Sinus", &buffer.Data[0].x, &buffer.Data[0].y, buffer.Data.size(), 0, buffer.Offset, 2 * sizeof(double));
+    // }
+}
+
+void Plotter::plotPowerSpectrum(std::vector<SignalBuffer> &signals) {
+    static ImPlotAxisFlags xflags = ImPlotAxisFlags_None;
+    static ImPlotAxisFlags yflags = ImPlotAxisFlags_AutoFit | ImPlotAxisFlags_RangeFit;
+    ImPlot::SetupAxes("Frequency (Hz)", "Power Density (dB)", xflags, yflags);
+    ImPlot::SetupAxisLimits(ImAxis_X1, 0, 7, ImGuiCond_Always);
+    ImPlot::SetNextFillStyle(IMPLOT_AUTO_COL, 0.5f);
+    // if (buffer.Data.size() > 0) {
+    //     // ImPlot::PlotLine("Sinus", &buffer.Data[0].x, &buffer.Data[0].y, buffer.Data.size(), 0, buffer.Offset, 2 * sizeof(double));
+    // }
+}

--- a/src/implot_visualization/app/plot_tools/plot_tools.cpp
+++ b/src/implot_visualization/app/plot_tools/plot_tools.cpp
@@ -36,15 +36,12 @@ void Plotter::plotBandpassFilter(std::vector<SignalBuffer> &signals) {
     ImPlot::SetupAxes("time (ms)", "I(A)", xflags, yflags);
     ImPlot::SetupAxisLimits(ImAxis_X1, 0, 60, ImGuiCond_Always);
     ImPlot::SetNextFillStyle(IMPLOT_AUTO_COL, 0.5f);
-    // if (buffer.Data.size() > 0) {
-    //     // ImPlot::PlotLine("Sinus", &buffer.Data[0].x, &buffer.Data[0].y, buffer.Data.size(), 0, buffer.Offset, 2 * sizeof(double));
-    // }
+    // plotSignals(signals);
 }
 
 void Plotter::plotPower(std::vector<SignalBuffer> &signals) {
     static ImPlotAxisFlags xflags = ImPlotAxisFlags_None;
     static ImPlotAxisFlags yflags = ImPlotAxisFlags_AutoFit | ImPlotAxisFlags_RangeFit;
-    // Setup x-Axis
     ImPlot::SetupAxes("time (s)", "P(W), Q(Var), S(VA)", xflags, yflags);
     auto   clock       = std::chrono::system_clock::now();
     double currentTime = (std::chrono::duration_cast<std::chrono::milliseconds>(clock.time_since_epoch()).count()) / 1000.0;
@@ -52,17 +49,7 @@ void Plotter::plotPower(std::vector<SignalBuffer> &signals) {
     ImPlot::SetupAxisScale(ImAxis_X1, ImPlotScale_Time);
     ImPlot::SetupAxis(ImAxis_Y2, "phi(deg)", ImPlotAxisFlags_AuxDefault);
     ImPlot::SetNextFillStyle(IMPLOT_AUTO_COL, 0.5f);
-    for (int i = 0; i < signals.size(); i++) {
-        if (signals[i].data.size() > 0) {
-            ImPlot::PlotLine((signals[i].signalName).c_str(),
-                    &signals[i].data[0].x,
-                    &signals[i].data[0].y,
-                    signals[i].data.size(),
-                    0,
-                    signals[i].offset,
-                    2 * sizeof(double));
-        }
-    }
+    plotSignals(signals);
 }
 
 void Plotter::plotMainsFrequency(std::vector<SignalBuffer> &signals) {
@@ -74,9 +61,7 @@ void Plotter::plotMainsFrequency(std::vector<SignalBuffer> &signals) {
     ImPlot::SetupAxisLimits(ImAxis_X1, currentTime - 10.0, currentTime, ImGuiCond_Always);
     ImPlot::SetupAxisScale(ImAxis_X1, ImPlotScale_Time);
     ImPlot::SetNextFillStyle(IMPLOT_AUTO_COL, 0.5f);
-    // if (buffer.Data.size() > 0) {
-    //     // ImPlot::PlotLine("Sinus", &buffer.Data[0].x, &buffer.Data[0].y, buffer.Data.size(), 0, buffer.Offset, 2 * sizeof(double));
-    // }
+    // plotSignals(signals);
 }
 
 void Plotter::plotPowerSpectrum(std::vector<SignalBuffer> &signals) {
@@ -85,7 +70,5 @@ void Plotter::plotPowerSpectrum(std::vector<SignalBuffer> &signals) {
     ImPlot::SetupAxes("Frequency (Hz)", "Power Density (dB)", xflags, yflags);
     ImPlot::SetupAxisLimits(ImAxis_X1, 0, 7, ImGuiCond_Always);
     ImPlot::SetNextFillStyle(IMPLOT_AUTO_COL, 0.5f);
-    // if (buffer.Data.size() > 0) {
-    //     // ImPlot::PlotLine("Sinus", &buffer.Data[0].x, &buffer.Data[0].y, buffer.Data.size(), 0, buffer.Offset, 2 * sizeof(double));
-    // }
+    // plotSignals(signals);
 }

--- a/src/implot_visualization/app/plot_tools/plot_tools.h
+++ b/src/implot_visualization/app/plot_tools/plot_tools.h
@@ -1,0 +1,19 @@
+#pragma once
+
+#include <deserialize_json.h>
+#include <vector>
+
+class Plotter {
+public:
+    // static ImPlotAxisFlags xflags = ImPlotAxisFlags_None;
+    // static ImPlotAxisFlags yflags = ImPlotAxisFlags_AutoFit | ImPlotAxisFlags_RangeFit;
+
+    void plotGrSignals(std::vector<SignalBuffer> &signals);
+    void plotBandpassFilter(std::vector<SignalBuffer> &signals);
+    void plotPower(std::vector<SignalBuffer> &signals);
+    void plotMainsFrequency(std::vector<SignalBuffer> &signals);
+    void plotPowerSpectrum(std::vector<SignalBuffer> &signals);
+
+private:
+    void plotSignals(std::vector<SignalBuffer> &signals);
+};

--- a/src/opencmw_worker/src/TimeDomainWorker.hpp
+++ b/src/opencmw_worker/src/TimeDomainWorker.hpp
@@ -139,6 +139,9 @@ public:
                     //  generate multiarray values from strided array
                     size_t channelValuesSize = stridedValues.size() / requestedSignals.size();
                     _reply.channelValues     = opencmw::MultiArray<float, 2>(std::move(stridedValues), { requestedSignals.size(), channelValuesSize });
+                    // std::cout << "Dims: " << _reply.channelValues.n(0) << ", " << _reply.channelValues.n(1) << std::endl;
+                    // std::cout << "ChannelValues length: " << stridedValues.size() << std::endl;
+                    std::cout << _reply.channelNames[0] << std::endl;
                     //  generate relative timestamps
                     _reply.channelTimeSinceRefTrigger.clear();
                     _reply.channelTimeSinceRefTrigger.reserve(channelValuesSize);

--- a/src/opencmw_worker/src/TimeDomainWorker.hpp
+++ b/src/opencmw_worker/src/TimeDomainWorker.hpp
@@ -139,9 +139,6 @@ public:
                     //  generate multiarray values from strided array
                     size_t channelValuesSize = stridedValues.size() / requestedSignals.size();
                     _reply.channelValues     = opencmw::MultiArray<float, 2>(std::move(stridedValues), { requestedSignals.size(), channelValuesSize });
-                    // std::cout << "Dims: " << _reply.channelValues.n(0) << ", " << _reply.channelValues.n(1) << std::endl;
-                    // std::cout << "ChannelValues length: " << stridedValues.size() << std::endl;
-                    std::cout << _reply.channelNames[0] << std::endl;
                     //  generate relative timestamps
                     _reply.channelTimeSinceRefTrigger.clear();
                     _reply.channelTimeSinceRefTrigger.reserve(channelValuesSize);

--- a/src/opencmw_worker/src/TimeDomainWorker.hpp
+++ b/src/opencmw_worker/src/TimeDomainWorker.hpp
@@ -16,18 +16,18 @@ struct TimeDomainContext {
     std::string             channelNameFilter;
     int32_t                 acquisitionModeFilter = 0; // STREAMING
     std::string             triggerNameFilter;
-    int32_t                 maxClientUpdateFrequencyFilter;
-    opencmw::MIME::MimeType contentType = opencmw::MIME::JSON;
+    int32_t                 maxClientUpdateFrequencyFilter = 25;
+    opencmw::MIME::MimeType contentType                    = opencmw::MIME::JSON;
 };
 
 ENABLE_REFLECTION_FOR(TimeDomainContext, channelNameFilter, acquisitionModeFilter, triggerNameFilter, maxClientUpdateFrequencyFilter, contentType)
 
 struct Acquisition {
-    std::string                   refTriggerName = { "NO_REF_TRIGGER" };
-    int64_t                       refTriggerStamp;
+    std::string                   refTriggerName  = { "NO_REF_TRIGGER" };
+    int64_t                       refTriggerStamp = 0;
     std::vector<float>            channelTimeSinceRefTrigger;
-    float                         channelUserDelay;
-    float                         channelActualDelay;
+    float                         channelUserDelay   = 0.0f;
+    float                         channelActualDelay = 0.0f;
     std::vector<std::string>      channelNames;
     opencmw::MultiArray<float, 2> channelValues;
     opencmw::MultiArray<float, 2> channelErrors;
@@ -189,7 +189,7 @@ public:
                                      TimeDomainContext & /*replyContext*/, Acquisition   &out) {
             std::set<std::string, std::less<>> requestedSignals;
             if (!checkRequestedSignals(requestContext, requestedSignals)) {
-                // break; // TODO: Throw EXCEPTION
+                return;
             }
 
             // find how many chunks should be parallely polled

--- a/src/opencmw_worker/src/TimeDomainWorker.hpp
+++ b/src/opencmw_worker/src/TimeDomainWorker.hpp
@@ -81,6 +81,12 @@ public:
             while (!_shutdownRequested) {
                 std::chrono::time_point time_start = std::chrono::system_clock::now();
 
+                static size_t           subs       = 0;
+                if (subs != super_t::activeSubscriptions().size()) {
+                    subs = super_t::activeSubscriptions().size();
+                    fmt::print("TimeDomainWorker: activeSubs: {}\n", subs);
+                }
+
                 for (auto subTopic : super_t::activeSubscriptions()) { // loop over active subscriptions
 
                     const auto                         queryMap = subTopic.queryParamMap();


### PR DESCRIPTION
Hi Alex,

I found a bug in the synchronous fetch that lead to an overload of http requests. That's why we had chunk duplicates of the signals. Here is a draft pull request that fixes this bug and also uses multiple subscriptions. I also added a visualization of the reference trigger timestamps for debug reasons.

The code is not clean yet, but I appreciate your feedback on the current status :)

resolves #22 