### PR TITLE
add prometheus with custom exporter

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -108,3 +108,8 @@ cmake-build*/
 
 # gnuradio-prefix dir for installing
 gr-prefix/
+
+# prometheus
+src/prometheus/json_exporter/data.json
+src/prometheus/json_exporter/fair-main.code-workspace
+src/prometheus/json_exporter/requests.http


### PR DESCRIPTION
I have written an exporter in Python that converts json to metrics from Prometheus. When I transfer json files with only up to five data points, all data points are displayed correctly in the dashboard. As soon as I try to transfer more data points (tested with 16382 data points), the dashboard does not look as expected (see picture 1).
In the json exporter the data points can be viewed (see picture 2). All points were transferred correctly. In Prometheus, the data is compressed, so it is not possible to view the data points. You can only view the number of data points, which corresponds to the number of data points in the Json format. However, in the visualization it looks as if about 3 points have been captured (see picture 1).

picture 1:
 ![Screenshot (41)](https://user-images.githubusercontent.com/119943143/211564445-c81a1c4f-2952-48b1-a4c0-aac2f03c81cc.png)

picture 2:
![Screenshot (42)](https://user-images.githubusercontent.com/119943143/211564414-f2f83e55-a8ba-44a0-b469-c47a1946123b.png)

