### PR TITLE
Trigger CI workflow for PRs on develop

### DIFF
--- a/.github/workflows/ci_pulsed_power_monitoring.yml
+++ b/.github/workflows/ci_pulsed_power_monitoring.yml
@@ -4,7 +4,7 @@ on:
   push:
     branches: ["*"]
   pull_request:
-    branches: [main]
+    branches: [main, develop]
   release:
     types: [created]
 


### PR DESCRIPTION
Trigger the CI workflow for PRs on main and develop in order to detect bugs earlier.